### PR TITLE
fix(MMAP-30): handle empty value of input field without default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Unreleased
 - added option `max_depth` used to specify the maximum depth of level's schema that have to be rendered
 - added option `use_default_values` used to specify if default values based on the "type" of the property have to be used
+- when `use_default_values` is false, number and integer fields have undefined value when input is empty
+- when `use_default_values` is false, string fields have undefined value at the beginning. After that user edit the field, empty input means empty string
 
 ### 2.3.0-dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - added option `max_depth` used to specify the maximum depth of level's schema that have to be rendered
 - added option `use_default_values` used to specify if default values based on the "type" of the property have to be used
 - when `use_default_values` is false, number and integer fields have undefined value when input is empty
-- when `use_default_values` is false, string fields have undefined value at the beginning. After that user edit the field, empty input means empty string
+- when `use_default_values` is false, string fields have undefined value at the beginning. After that user edit the field, empty input is threated as an empty string
 
 ### 2.3.0-dev
 

--- a/src/editors/integer.js
+++ b/src/editors/integer.js
@@ -10,6 +10,10 @@ export class IntegerEditor extends NumberEditor {
     if (!this.dependenciesFulfilled) {
       return undefined
     }
-    return isInteger(this.value) ? parseInt(this.value) : this.value
+    const value = isInteger(this.value) ? parseInt(this.value) : this.value
+    if (!this.jsoneditor.options.use_default_values && value === '') {
+      return undefined
+    }
+    return value
   }
 }

--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -42,6 +42,10 @@ export class NumberEditor extends StringEditor {
     if (!this.dependenciesFulfilled) {
       return undefined
     }
-    return isNumber(this.value) ? parseFloat(this.value) : this.value
+    const value = isNumber(this.value) ? parseFloat(this.value) : this.value
+    if (!this.jsoneditor.options.use_default_values && value === '') {
+      return undefined
+    }
+    return value
   }
 }

--- a/tests/codeceptjs/editors/option-no_default_values_test.js
+++ b/tests/codeceptjs/editors/option-no_default_values_test.js
@@ -1,0 +1,42 @@
+var assert = require('assert')
+
+Feature('option no_default_values')
+
+Scenario('should have correct initial value', async (I) => {
+  I.amOnPage('option-no_default_values.html')
+  I.click('.get-value')
+  assert.equal(await I.grabValueFrom('.debug'), JSON.stringify({
+    integer: undefined,
+    number: undefined,
+    string: undefined
+  }))
+})
+
+Scenario('should have correct values on empty dirty field', async (I) => {
+  I.amOnPage('option-no_default_values.html')
+  I.click('.get-value')
+
+  await I.fillField('[name="root[integer]"]', '3')
+  await I.fillField('[name="root[number]"]', '3')
+  await I.fillField('[name="root[string]"]', 'foo')
+  I.click('.force-change')
+  I.click('.get-value')
+
+  assert.equal(await I.grabValueFrom('.debug'), JSON.stringify({
+    number: 3.0,
+    string: 'foo',
+    integer: 3
+  }))
+
+  await I.clearField('[name="root[integer]"]')
+  await I.clearField('[name="root[number]"]')
+  await I.clearField('[name="root[string]"]')
+  I.click('.force-change')
+  I.click('.get-value')
+
+  assert.equal(await I.grabValueFrom('.debug'), JSON.stringify({
+    number: undefined,
+    string: '',
+    integer: undefined
+  }))
+})

--- a/tests/pages/option-no_default_values.html
+++ b/tests/pages/option-no_default_values.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>wysiwyg-sceditor</title>
+
+  <!-- json editor -->
+  <script src="../../dist/jsoneditor.js"></script>
+
+  <!-- jquery -->
+  <script src="./../../node_modules/jquery/dist/jquery.min.js"></script>
+
+</head>
+<body>
+
+<textarea class="debug" cols="30" rows="10"></textarea>
+<button class='get-value'>Get Value</button>
+<div class='container'></div>
+<button class="force-change">Force onchange</button>
+<script>
+  var container = document.querySelector('.container');
+  var debug = document.querySelector('.debug');
+
+  var schema =  {
+        "type": "object",
+        "properties": {
+            "number": {
+                "type": "number"
+            },
+            "string": {
+                "type": "string"
+            },
+            "integer": {
+                "type": "integer"
+            },
+        }
+    };
+  
+  var editor = new JSONEditor(container, {
+    schema: schema,
+    use_default_values: false,
+    remove_empty_properties: false
+  });
+
+  document.querySelector('.get-value').addEventListener('click', function () {
+    debug.value = JSON.stringify(editor.getValue());
+  });
+
+  document.querySelector('.force-change').addEventListener('click', function () {
+    document.querySelector('[name="root[integer]"]').dispatchEvent(new Event('change'));
+    document.querySelector('[name="root[number]"]').dispatchEvent(new Event('change'));
+    document.querySelector('[name="root[string]"]').dispatchEvent(new Event('change'));
+  });
+
+</script>
+
+</body>
+</html>

--- a/tests/unit/core.spec.js
+++ b/tests/unit/core.spec.js
@@ -190,20 +190,88 @@ describe('JSONEditor', function () {
   })
 
   describe('use_default_values', () => {
-    it('false - do not auto-set default values', () => {
-      editor = new JSONEditor(element, {
-        schema: someTypes,
-        use_default_values: false
+    describe('false', () => {
+      it('do not auto-set default values', () => {
+        editor = new JSONEditor(element, {
+          schema: someTypes,
+          use_default_values: false
+        })
+
+        expect(editor.getValue()).toEqual({
+          boolean: undefined,
+          enum: undefined,
+          integer: undefined,
+          number: undefined,
+          string: undefined,
+          object: {},
+          array: []
+        })
       })
 
-      expect(editor.getValue()).toEqual({
-        boolean: undefined,
-        enum: undefined,
-        integer: '',
-        number: '',
-        string: '',
-        object: {},
-        array: []
+      it('returns correct values on dirty input text fields', () => {
+        editor = new JSONEditor(element, {
+          schema: someTypes,
+          use_default_values: false
+        })
+
+        expect(editor.getValue()).toEqual({
+          boolean: undefined,
+          enum: undefined,
+          integer: undefined,
+          number: undefined,
+          string: undefined,
+          object: {},
+          array: []
+        })
+
+        fillField('root[integer]', 3)
+        fillField('root[number]', 4)
+        fillField('root[string]', 'foo')
+
+        expect(editor.getValue()).toEqual({
+          boolean: undefined,
+          enum: undefined,
+          integer: 3,
+          number: 4,
+          string: 'foo',
+          object: {},
+          array: []
+        })
+
+        fillField('root[integer]', '')
+        fillField('root[number]', '')
+        fillField('root[string]', '')
+
+        expect(editor.getValue()).toEqual({
+          boolean: undefined,
+          enum: undefined,
+          integer: undefined,
+          number: undefined,
+          string: '',
+          object: {},
+          array: []
+        })
+      })
+
+      it('returns default value from schema if set', () => {
+        editor = new JSONEditor(element, {
+          schema: {
+            type: 'object',
+            properties: {
+              string_with_default: { type: 'string', default: 'foobar' },
+              string_without_default: { type: 'string' },
+              enum_with_default: { type: 'string', enum: ['foobar', 'lorem'], default: 'foobar' },
+              enum_without_default: { type: 'string', enum: ['foobar', 'lorem'] }
+            }
+          },
+          use_default_values: false,
+          remove_empty_properties: true
+        })
+
+        expect(editor.getValue()).toEqual({
+          string_with_default: 'foobar',
+          enum_with_default: 'foobar'
+        })
       })
     })
 
@@ -223,26 +291,10 @@ describe('JSONEditor', function () {
         array: []
       })
     })
-
-    it('false - returns default value from schema if set', () => {
-      editor = new JSONEditor(element, {
-        schema: {
-          type: 'object',
-          properties: {
-            string_with_default: { type: 'string', default: 'foobar' },
-            string_without_default: { type: 'string' },
-            enum_with_default: { type: 'string', enum: ['foobar', 'lorem'], default: 'foobar' },
-            enum_without_default: { type: 'string', enum: ['foobar', 'lorem'] }
-          }
-        },
-        use_default_values: false,
-        remove_empty_properties: true
-      })
-
-      expect(editor.getValue()).toEqual({
-        string_with_default: 'foobar',
-        enum_with_default: 'foobar'
-      })
-    })
   })
 })
+
+function fillField (fieldName, value) {
+  document.querySelector(`[name="${fieldName}"]`).value = value
+  document.querySelector(`[name="${fieldName}"]`).dispatchEvent(new Event('change'))
+}


### PR DESCRIPTION
with use_default_values false handle undefined as string initial value

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks backward-compatibility?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
| Updated README/docs?   | ❌
| Added CHANGELOG entry?   | ✔️
